### PR TITLE
Add owner tag to problem parser

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,6 +11,7 @@
                 "main.asm"
             ],
             "problemMatcher": {
+                "owner": "sjasmplus",
                 "fileLocation": [
                     "relative",
                     "${workspaceRoot}"


### PR DESCRIPTION
This fixes an issue with the VS code problems list where a rebuild after fixing an error doesn't clear the problems list.
This means that sjplusasm errors don't clear correctly.
See https://github.com/microsoft/vscode/issues/129341
fixes Issue #6 